### PR TITLE
Remove lint from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ All the tasks necessary for testing, building and deploying this code is already
 
 Try these:
 
-* `act -j lint` - run the linter
 * `act -j test` - run the tests
 * `act` - run the the entire pipeline
 * `act -l` - view the execution graph


### PR DESCRIPTION
The `lint` workflow has been removed at https://github.com/cplee/github-actions-demo/commit/6c8e1e69352bc2cedbeaf663b95ec5628810bc60 

However it's still part of the documentation at README.
This PR removes this info as well.